### PR TITLE
fix: clamp deltaTime on background return & ci: auto-versioning

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,6 +21,8 @@ jobs:
           node-version: '24.14.0'
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
+      - name: Clean working directory
+        run: git checkout -- .
       - name: Determine version bump
         id: version
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,9 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - name: Clean working directory
-        run: git checkout -- .
+        run: |
+          git checkout -- .
+          git clean -fd
       - name: Determine version bump
         id: version
         run: |


### PR DESCRIPTION
## Summary
- バックグラウンドからの復帰時に `deltaTime` が巨大な値になりアニメーションがジャンプする問題を修正
- `animate()` 内で `deltaTime` を `MAX_DELTA_TIME`（0.1秒 = 100ms）でクランプ
- Node.js を **24.14.0**（最新）にアップグレード、`actions/setup-node` を v4 に更新
- PR マージ時に **PR ラベルに応じたバージョンバンプ + npm publish** を自動実行するように変更
  - `major` ラベル → メジャーアップデート
  - `minor` ラベル → マイナーアップデート
  - ラベルなし → パッチアップデート（デフォルト）
- `pr.yaml` を PR オープン時にテスト実行するように修正

## Test plan
- [x] 既存テスト全10件パス
- [x] バックグラウンド復帰シミュレーションテスト追加・パス
- [ ] ブラウザで実際にタブをバックグラウンドにして復帰後のアニメーション挙動を確認
- [ ] PR ワークフローが Node 24 でビルド成功することを確認
- [ ] ラベルなしでマージし patch バージョンが自動で上がることを確認

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)